### PR TITLE
Make PMI reader accept file and dir as input

### DIFF
--- a/dpar-utils/src/bin/dpar-train.rs
+++ b/dpar-utils/src/bin/dpar-train.rs
@@ -75,6 +75,8 @@ fn main() {
         .parser
         .load_inputs()
         .or_exit("Cannot load lookups", 1);
+
+    eprintln!("Reading in association measures...");
     let association_strengths = config
         .parser
         .load_associations()

--- a/dpar-utils/src/config.rs
+++ b/dpar-utils/src/config.rs
@@ -15,7 +15,7 @@ use dpar::features::{AddressedValues, Layer, LayerLookups};
 use dpar::models::lr::ExponentialDecay;
 use dpar::models::tensorflow::{LayerOp, LayerOps};
 
-use util::associations_from_buf_read;
+use util::associations_from_files;
 use StoredLookupTable;
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -67,8 +67,8 @@ impl Parser {
     }
 
     pub fn load_associations(&self) -> Result<HashMap<(String, String, String), f32>, Error> {
-        let f = File::open(&self.associations)?;
-        Ok(associations_from_buf_read(f)?)
+        let path = Path::new(&self.associations);
+        Ok(associations_from_files(&path)?)
     }
 }
 

--- a/dpar-utils/src/lib.rs
+++ b/dpar-utils/src/lib.rs
@@ -41,7 +41,7 @@ mod stored_table;
 pub use stored_table::StoredLookupTable;
 
 mod util;
-pub use util::associations_from_buf_read;
+pub use util::associations_from_files;
 
 #[cfg(test)]
 #[macro_use]

--- a/dpar-utils/src/util.rs
+++ b/dpar-utils/src/util.rs
@@ -1,31 +1,63 @@
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
+use std::path::Path;
 
 use failure::Error;
 
-/// Read association strengths for dependency triples from a text file.
+/// Read association strengths for dependency triples from text files in
+/// a directory or from a single file.
 ///
-/// Such a text file consists of lines with the tab-separated format
+/// A text file consists of lines with the tab-separated format
 ///
 /// ~~~text,no_run
-/// [token+] [token+] [deprel+] association_strength
+/// [token+] [token+] association_strength
 /// ~~~
-pub fn associations_from_buf_read(
-    f: File,
+///
+/// The file is named with the dependency relation of which head-dependent
+/// pairs are listed with their association measure in the file.
+///
+/// E.g. the file is called `SUBJ.assoc` and contains all tokens related via the
+/// SUBJ relation and their association measure.
+pub fn associations_from_files(
+    dir: &Path,
 ) -> Result<HashMap<(String, String, String), f32>, Error> {
     let mut association_strengths: HashMap<(String, String, String), f32> = HashMap::new();
-    for l in BufReader::new(f).lines() {
-        let l = l.unwrap();
-        let line = l.split("\t").collect::<Vec<_>>();
-        association_strengths.insert(
-            (
-                line[0].to_string(),
-                line[1].to_string(),
-                line[2].to_string(),
-            ),
-            line[3].parse::<f32>().unwrap(),
-        );
+
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_file() {
+                let f = File::open(&path)?;
+                for l in BufReader::new(f).lines() {
+                    let l = l.unwrap();
+                    let line = l.split("\t").collect::<Vec<_>>();
+                    association_strengths.insert(
+                        (
+                            line[0].to_string(),
+                            line[1].to_string(),
+                            path.file_stem().unwrap().to_string_lossy().to_string(),
+                        ),
+                        line[2].parse::<f32>().unwrap(),
+                    );
+                }
+            }
+        }
+    } else if dir.is_file() {
+        let f = File::open(&dir)?;
+        for l in BufReader::new(f).lines() {
+            let l = l.unwrap();
+            let line = l.split("\t").collect::<Vec<_>>();
+            association_strengths.insert(
+                (
+                    line[0].to_string(),
+                    line[1].to_string(),
+                    dir.file_stem().unwrap().to_string_lossy().to_string(),
+                ),
+                line[2].parse::<f32>().unwrap(),
+            );
+        }
     }
+
     Ok(association_strengths)
 }


### PR DESCRIPTION
Change PMI reader to also accept directory as input and adjust `HashMap` to read the name of the file as the dependency relation. The expected input is thus from a `deprel.sc` file:
```
word1 \t word2 \t pmi
```
which will be read into the `HashMap` as (key) (value) pair in this format:
```
(word1, word2, deprel) (pmi)
```