### PR TITLE
Extended PMI lookup functionality and PMI reading bugfixes

### DIFF
--- a/dpar-utils/src/bin/dpar-parse.rs
+++ b/dpar-utils/src/bin/dpar-parse.rs
@@ -5,7 +5,6 @@ extern crate failure;
 extern crate getopts;
 extern crate stdinout;
 
-use std::collections::HashMap;
 use std::env::args;
 use std::fs::File;
 use std::io::{BufRead, BufWriter, Write};
@@ -108,7 +107,7 @@ where
     let inputs = config.parser.load_inputs()?;
     let lookups = config.lookups.load_lookups()?;
     let layer_ops = config.lookups.layer_ops();
-    let association_strengths = HashMap::new();
+    let association_strengths = config.parser.load_associations()?;
     let vectorizer = InputVectorizer::new(lookups, inputs, association_strengths);
     let system: S = load_system_generic(config)?;
     let guide = load_model(&config, system, vectorizer, &layer_ops)?;

--- a/dpar-utils/tensorflow/model.py
+++ b/dpar-utils/tensorflow/model.py
@@ -109,7 +109,7 @@ class ParseModel:
 
         n_attachment_addrs = 2
         self._assoc_strengths = tf.placeholder(
-            tf.float32, [batch_size, n_deprel_embeds * n_attachment_addrs], "assoc_strengths")
+            tf.float32, [batch_size, 2 * n_deprel_embeds * n_attachment_addrs], "assoc_strengths")
 
         # Features are converted to a one-hot representation.
         n_features = int(shapes["n_features"])

--- a/dpar/src/models/tensorflow/collector.rs
+++ b/dpar/src/models/tensorflow/collector.rs
@@ -119,7 +119,7 @@ where
             self.labels.push(Tensor::new(&[self.batch_size as u64]));
             self.non_lookup_inputs.push(Tensor::new(&[
                 self.batch_size as u64,
-                (n_deprel_embeds * T::ATTACHMENT_ADDRS.len()) as u64,
+                (2 * n_deprel_embeds * T::ATTACHMENT_ADDRS.len()) as u64,
             ]));
         }
 
@@ -128,7 +128,7 @@ where
         let label = self.transition_system.transitions().lookup(t.clone());
         self.labels[batch][self.instance_idx] = label as i32;
 
-        let n_non_lookup_inputs = n_deprel_embeds * T::ATTACHMENT_ADDRS.len();
+        let n_non_lookup_inputs = 2 * n_deprel_embeds * T::ATTACHMENT_ADDRS.len();
         self.vectorizer.realize_into(
             state,
             &mut self.lookup_inputs[batch].to_instance_slices(self.instance_idx),
@@ -197,7 +197,7 @@ mod tests {
         // Check batch shapes.
         assert_eq!(labels[0].dims(), &[2]);
         assert_eq!(lookup_inputs[0][features::Layer::Token].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
         assert_eq!(lookup_inputs[0][features::Layer::DepRel].dims(), &[2, 0]);
 
         // Check batch contents.
@@ -206,7 +206,10 @@ mod tests {
             lookup_inputs[0][features::Layer::Token].as_ref(),
             &[1, 2, 2, 3]
         );
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
     }
 
     #[test]
@@ -241,10 +244,10 @@ mod tests {
         // Check batch shapes.
         assert_eq!(labels[0].dims(), &[2]);
         assert_eq!(lookup_inputs[0][features::Layer::Token].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
         assert_eq!(labels[1].dims(), &[1]);
         assert_eq!(lookup_inputs[1][features::Layer::Token].dims(), &[1, 2]);
-        assert_eq!(non_lookup_inputs[1].dims(), &[1, 2]);
+        assert_eq!(non_lookup_inputs[1].dims(), &[1, 4]);
 
         // Check batch contents.
         assert_eq!(&*labels[0], &[1, 1]);
@@ -252,10 +255,13 @@ mod tests {
             lookup_inputs[0][features::Layer::Token].as_ref(),
             &[1, 2, 2, 3]
         );
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
         assert_eq!(&*labels[1], &[2]);
         assert_eq!(lookup_inputs[1][features::Layer::Token].as_ref(), &[3, 4]);
-        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0]);
+        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0, 0.0, 0.0]);
     }
 
     #[test]
@@ -290,12 +296,18 @@ mod tests {
         assert_eq!(non_lookup_inputs.len(), 2);
 
         // Check batch shapes.
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[1].dims(), &[2, 2]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[1].dims(), &[2, 4]);
 
         // Check batch contents.
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
-        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(
+            &*non_lookup_inputs[1],
+            &[0.0, 0.0, 0.0, 0.0, 0.7, 1.0, 0.7, 1.0]
+        );
     }
 
     #[test]
@@ -338,16 +350,22 @@ mod tests {
         assert_eq!(non_lookup_inputs.len(), 3);
 
         // Check batch shapes.
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[1].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[2].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[1].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[2].dims(), &[2, 8]);
 
         // Check batch contents.
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
-        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(
+            &*non_lookup_inputs[1],
+            &[0.0, 0.0, 0.0, 0.0, 0.7, 1.0, 0.7, 1.0]
+        );
         assert_eq!(
             &*non_lookup_inputs[2],
-            &[0.5, 0.5, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.7, 1.0, 0.7, 1.0, 0.7, 1.0, 0.7, 1.0]
         );
     }
 
@@ -411,7 +429,7 @@ mod tests {
                 "ROOT".to_string(),
                 "FOO".to_string(),
             ),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             (
@@ -419,23 +437,23 @@ mod tests {
                 "collector".to_string(),
                 "FOO".to_string(),
             ),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("ROOT".to_string(), "test".to_string(), "FOO".to_string()),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("test".to_string(), "ROOT".to_string(), "FOO".to_string()),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("ROOT".to_string(), "test".to_string(), "BAR".to_string()),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("test".to_string(), "ROOT".to_string(), "BAR".to_string()),
-            1.0,
+            0.7,
         );
 
         InputVectorizer::new(

--- a/dpar/src/models/tensorflow/guide.rs
+++ b/dpar/src/models/tensorflow/guide.rs
@@ -39,17 +39,18 @@ where
             .layer_lookup(Layer::DepRel)
             .unwrap()
             .len();
-        let mut input_non_lookup_tensors = Tensor::new(&[
-            states.len() as u64,
-            (n_deprel_embeds * T::ATTACHMENT_ADDRS.len()) as u64,
-        ]);
+        let n_non_lookup_inputs = 2 * n_deprel_embeds * T::ATTACHMENT_ADDRS.len();
+        let mut input_non_lookup_tensors =
+            Tensor::new(&[states.len() as u64, n_non_lookup_inputs as u64]);
 
         // Fill tensors.
         for (idx, state) in states.iter().enumerate() {
             self.vectorizer().realize_into(
                 state,
                 &mut input_lookup_tensors.to_instance_slices(idx),
-                &mut input_non_lookup_tensors,
+                &mut input_non_lookup_tensors[(idx * n_non_lookup_inputs)
+                                                  ..(idx * n_non_lookup_inputs
+                                                      + n_non_lookup_inputs)],
                 &T::ATTACHMENT_ADDRS,
             );
         }


### PR DESCRIPTION
This PR does two things to improve parser performance with PMIs:
1. It fixes bugs for processing PMIs in parsing which led to the PMI information only being available in training/validaiton but not in the parsing/testing procedure.
2. It also extends the functionality of PMI lookups by lowercasing all except the ROOT token and nouns (proper and common). Furthermore, the parser is now informed about whether a PMI originates from a looked-up value or from the default. A default PMI of 0.0 is assigned to any dependency triple that could not be found in the list of PMIs.