### PR TITLE
Add binary indicator whether a PMI was retrieved or default was used

### DIFF
--- a/dpar-utils/tensorflow/model.py
+++ b/dpar-utils/tensorflow/model.py
@@ -109,7 +109,7 @@ class ParseModel:
 
         n_attachment_addrs = 2
         self._assoc_strengths = tf.placeholder(
-            tf.float32, [batch_size, n_deprel_embeds * n_attachment_addrs], "assoc_strengths")
+            tf.float32, [batch_size, 2 * n_deprel_embeds * n_attachment_addrs], "assoc_strengths")
 
         # Features are converted to a one-hot representation.
         n_features = int(shapes["n_features"])

--- a/dpar/src/features/input_layers.rs
+++ b/dpar/src/features/input_layers.rs
@@ -193,7 +193,7 @@ impl InputVectorizer {
             .layer_lookup(Layer::DepRel)
             .unwrap()
             .len();
-        let mut non_lookup_layer = vec![0f32; n_deprel_embeds * attachment_addrs.len()];
+        let mut non_lookup_layer = vec![0f32; 2 * n_deprel_embeds * attachment_addrs.len()];
 
         self.realize_into(
             state,
@@ -302,18 +302,19 @@ impl InputVectorizer {
                 let head = addr_head.get(state);
                 let dependent = addr_dependent.get(state);
                 if let (Some(head), Some(dependent)) = (head, dependent) {
-                    let association = self.assoc_strength(&head, &dependent, &deprel);
-                    non_lookup_slice[idx] = association;
+                    let (association, found) = self.assoc_strength(&head, &dependent, &deprel);
+                    non_lookup_slice[idx * 2] = association;
+                    non_lookup_slice[idx * 2 + 1] = found;
                 }
             }
         }
     }
 
-    fn assoc_strength(&self, head: &str, dependent: &str, deprel: &str) -> f32 {
+    fn assoc_strength(&self, head: &str, dependent: &str, deprel: &str) -> (f32, f32) {
         let dep_triple = (head.to_string(), dependent.to_string(), deprel.to_string());
         match self.association_strengths.get(&dep_triple) {
-            Some(association_strength) => *association_strength,
-            None => 0.0,
+            Some(association_strength) => (*association_strength, 1.0),
+            None => (0.0, 0.0),
         }
     }
 }

--- a/dpar/src/features/input_layers.rs
+++ b/dpar/src/features/input_layers.rs
@@ -302,19 +302,19 @@ impl InputVectorizer {
                 let head = addr_head.get(state);
                 let dependent = addr_dependent.get(state);
                 if let (Some(head), Some(dependent)) = (head, dependent) {
-                    let (association, found) = self.assoc_strength(&head, &dependent, &deprel);
-                    non_lookup_slice[idx * 2] = association;
-                    non_lookup_slice[idx * 2 + 1] = found;
+                    let association = self.assoc_strength(&head, &dependent, &deprel);
+                    non_lookup_slice[idx * 2] = association.unwrap_or(0f32);
+                    non_lookup_slice[idx * 2 + 1] = association.map_or(0f32, |_| 1f32);
                 }
             }
         }
     }
 
-    fn assoc_strength(&self, head: &str, dependent: &str, deprel: &str) -> (f32, f32) {
+    fn assoc_strength(&self, head: &str, dependent: &str, deprel: &str) -> Option<f32> {
         let dep_triple = (head.to_string(), dependent.to_string(), deprel.to_string());
         match self.association_strengths.get(&dep_triple) {
-            Some(association_strength) => (*association_strength, 1.0),
-            None => (0.0, 0.0),
+            Some(association_strength) => Some(*association_strength),
+            None => None,
         }
     }
 }

--- a/dpar/src/models/tensorflow/collector.rs
+++ b/dpar/src/models/tensorflow/collector.rs
@@ -119,7 +119,7 @@ where
             self.labels.push(Tensor::new(&[self.batch_size as u64]));
             self.non_lookup_inputs.push(Tensor::new(&[
                 self.batch_size as u64,
-                (n_deprel_embeds * T::ATTACHMENT_ADDRS.len()) as u64,
+                (2 * n_deprel_embeds * T::ATTACHMENT_ADDRS.len()) as u64,
             ]));
         }
 
@@ -128,7 +128,7 @@ where
         let label = self.transition_system.transitions().lookup(t.clone());
         self.labels[batch][self.instance_idx] = label as i32;
 
-        let n_non_lookup_inputs = n_deprel_embeds * T::ATTACHMENT_ADDRS.len();
+        let n_non_lookup_inputs = 2 * n_deprel_embeds * T::ATTACHMENT_ADDRS.len();
         self.vectorizer.realize_into(
             state,
             &mut self.lookup_inputs[batch].to_instance_slices(self.instance_idx),
@@ -197,7 +197,7 @@ mod tests {
         // Check batch shapes.
         assert_eq!(labels[0].dims(), &[2]);
         assert_eq!(lookup_inputs[0][features::Layer::Token].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
         assert_eq!(lookup_inputs[0][features::Layer::DepRel].dims(), &[2, 0]);
 
         // Check batch contents.
@@ -206,7 +206,10 @@ mod tests {
             lookup_inputs[0][features::Layer::Token].as_ref(),
             &[1, 2, 2, 3]
         );
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
     }
 
     #[test]
@@ -241,10 +244,10 @@ mod tests {
         // Check batch shapes.
         assert_eq!(labels[0].dims(), &[2]);
         assert_eq!(lookup_inputs[0][features::Layer::Token].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
         assert_eq!(labels[1].dims(), &[1]);
         assert_eq!(lookup_inputs[1][features::Layer::Token].dims(), &[1, 2]);
-        assert_eq!(non_lookup_inputs[1].dims(), &[1, 2]);
+        assert_eq!(non_lookup_inputs[1].dims(), &[1, 4]);
 
         // Check batch contents.
         assert_eq!(&*labels[0], &[1, 1]);
@@ -252,10 +255,13 @@ mod tests {
             lookup_inputs[0][features::Layer::Token].as_ref(),
             &[1, 2, 2, 3]
         );
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
         assert_eq!(&*labels[1], &[2]);
         assert_eq!(lookup_inputs[1][features::Layer::Token].as_ref(), &[3, 4]);
-        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0]);
+        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0, 0.0, 0.0]);
     }
 
     #[test]
@@ -290,12 +296,18 @@ mod tests {
         assert_eq!(non_lookup_inputs.len(), 2);
 
         // Check batch shapes.
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[1].dims(), &[2, 2]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[1].dims(), &[2, 4]);
 
         // Check batch contents.
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
-        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(
+            &*non_lookup_inputs[1],
+            &[0.0, 0.0, 0.0, 0.0, 0.7, 1.0, 0.7, 1.0]
+        );
     }
 
     #[test]
@@ -338,16 +350,22 @@ mod tests {
         assert_eq!(non_lookup_inputs.len(), 3);
 
         // Check batch shapes.
-        assert_eq!(non_lookup_inputs[0].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[1].dims(), &[2, 2]);
-        assert_eq!(non_lookup_inputs[2].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[0].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[1].dims(), &[2, 4]);
+        assert_eq!(non_lookup_inputs[2].dims(), &[2, 8]);
 
         // Check batch contents.
-        assert_eq!(&*non_lookup_inputs[0], &[0.0, 0.0, 0.0, 0.0]);
-        assert_eq!(&*non_lookup_inputs[1], &[0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(
+            &*non_lookup_inputs[0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(
+            &*non_lookup_inputs[1],
+            &[0.0, 0.0, 0.0, 0.0, 0.7, 1.0, 0.7, 1.0]
+        );
         assert_eq!(
             &*non_lookup_inputs[2],
-            &[0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
+            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.7, 1.0, 0.7, 1.0, 0.7, 1.0, 0.7, 1.0]
         );
     }
 
@@ -411,7 +429,7 @@ mod tests {
                 "ROOT".to_string(),
                 "FOO".to_string(),
             ),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             (
@@ -419,23 +437,23 @@ mod tests {
                 "collector".to_string(),
                 "FOO".to_string(),
             ),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("ROOT".to_string(), "test".to_string(), "FOO".to_string()),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("test".to_string(), "ROOT".to_string(), "FOO".to_string()),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("ROOT".to_string(), "test".to_string(), "BAR".to_string()),
-            1.0,
+            0.7,
         );
         association_strengths.insert(
             ("test".to_string(), "ROOT".to_string(), "BAR".to_string()),
-            1.0,
+            0.7,
         );
 
         InputVectorizer::new(

--- a/dpar/src/models/tensorflow/guide.rs
+++ b/dpar/src/models/tensorflow/guide.rs
@@ -39,7 +39,7 @@ where
             .layer_lookup(Layer::DepRel)
             .unwrap()
             .len();
-        let n_non_lookup_inputs = n_deprel_embeds * T::ATTACHMENT_ADDRS.len();
+        let n_non_lookup_inputs = 2 * n_deprel_embeds * T::ATTACHMENT_ADDRS.len();
         let mut input_non_lookup_tensors =
             Tensor::new(&[states.len() as u64, n_non_lookup_inputs as u64]);
 


### PR DESCRIPTION
When PMIs for dependency triples are retrieved, it is possible that the PMI value that is found is equal to the default PMI that is returned whenever no PMI is available for a dependency triple. By adding a binary indicator that marks all retrieved PMIs with `1.0` and all default PMIs with `0.0`, the parser can distinguish the two kinds of values.
The `association_strengths` `HashMap` of PMIs in the tests of `collector.rs` used to contain PMIs of 1.0 for any dependency triple it contains. This would have resulted in (1.0, 1.0) tuples for any PMI retrieved from `association_strengths`. To make the test cases more readable, the PMIs have thus been changed to be `0.7`.