### PR TITLE
Add lowercasing for PMI lookup

### DIFF
--- a/dpar-utils/src/bin/dpar-parse.rs
+++ b/dpar-utils/src/bin/dpar-parse.rs
@@ -108,7 +108,9 @@ where
     let lookups = config.lookups.load_lookups()?;
     let layer_ops = config.lookups.layer_ops();
     let association_strengths = config.parser.load_associations()?;
-    let vectorizer = InputVectorizer::new(lookups, inputs, association_strengths);
+    let no_lowercase_tags = config.parser.no_lowercase_tags.clone();
+    let vectorizer =
+        InputVectorizer::new(lookups, inputs, association_strengths, no_lowercase_tags);
     let system: S = load_system_generic(config)?;
     let guide = load_model(&config, system, vectorizer, &layer_ops)?;
     let parser = GreedyParser::new(guide);

--- a/dpar-utils/src/bin/dpar-prepare.rs
+++ b/dpar-utils/src/bin/dpar-prepare.rs
@@ -121,7 +121,9 @@ where
     let lookups = config.lookups.create_lookups()?;
     let inputs = config.parser.load_inputs()?;
     let association_strenghts = config.parser.load_associations()?;
-    let vectorizer = InputVectorizer::new(lookups, inputs, association_strenghts);
+    let no_lowercase_tags = config.parser.no_lowercase_tags.clone();
+    let vectorizer =
+        InputVectorizer::new(lookups, inputs, association_strenghts, no_lowercase_tags);
     let system: S = S::default();
     let collector = NoopCollector::new(system, vectorizer)?;
     let mut trainer = GreedyTrainer::new(collector);

--- a/dpar-utils/src/bin/dpar-train.rs
+++ b/dpar-utils/src/bin/dpar-train.rs
@@ -79,7 +79,9 @@ fn main() {
         .parser
         .load_associations()
         .or_exit("Cannot load association strengths", 1);
-    let vectorizer = InputVectorizer::new(lookups, inputs, association_strengths);
+    let no_lowercase_tags = config.parser.no_lowercase_tags.clone();
+    let vectorizer =
+        InputVectorizer::new(lookups, inputs, association_strengths, no_lowercase_tags);
 
     eprintln!("Vectorizing training data...");
     let (train_labels, train_lookup_inputs, train_non_lookup_inputs) =

--- a/dpar-utils/src/config.rs
+++ b/dpar-utils/src/config.rs
@@ -56,6 +56,7 @@ pub struct Parser {
     pub inputs: String,
     pub transitions: String,
     pub associations: String,
+    pub no_lowercase_tags: Vec<String>,
     pub train_batch_size: usize,
     pub parse_batch_size: usize,
 }

--- a/dpar-utils/src/config_tests.rs
+++ b/dpar-utils/src/config_tests.rs
@@ -10,6 +10,7 @@ lazy_static! {
             inputs: String::from("parser.inputs"),
             transitions: String::from("parser.transitions"),
             associations: String::from("parser.associations"),
+            no_lowercase_tags: vec!["TAG".to_string()],
             train_batch_size: 8000,
             parse_batch_size: 4000,
         },

--- a/dpar-utils/testdata/basic-parse.conf
+++ b/dpar-utils/testdata/basic-parse.conf
@@ -4,6 +4,7 @@ system = "stackproj"
 inputs = "parser.inputs"
 transitions = "parser.transitions"
 associations = "parser.associations"
+no_lowercase_tags = ["TAG"]
 train_batch_size = 8000
 parse_batch_size = 4000
 

--- a/dpar/src/models/tensorflow/collector.rs
+++ b/dpar/src/models/tensorflow/collector.rs
@@ -369,11 +369,13 @@ mod tests {
         lookups.insert(features::Layer::DepRel, deprel_table);
 
         let association_strengths = HashMap::new();
+        let no_lowercase_tags = vec!["ROOT".to_string(), "NN".to_string(), "NE".to_string()];
 
         InputVectorizer::new(
             lookups,
             AddressedValues(vec![stack0, buffer0]),
             association_strengths,
+            no_lowercase_tags,
         )
     }
 
@@ -437,11 +439,13 @@ mod tests {
             ("test".to_string(), "ROOT".to_string(), "BAR".to_string()),
             1.0,
         );
+        let no_lowercase_tags = vec!["ROOT".to_string(), "NN".to_string(), "NE".to_string()];
 
         InputVectorizer::new(
             lookups,
             AddressedValues(vec![stack0, stack1, stack0_ldep0, stack1_rdep0]),
             association_strengths,
+            no_lowercase_tags,
         )
     }
 

--- a/dpar/src/models/tensorflow/model.rs
+++ b/dpar/src/models/tensorflow/model.rs
@@ -607,6 +607,7 @@ mod tests {
             LayerLookups::new(),
             AddressedValues(Vec::new()),
             HashMap::new(),
+            Vec::new()
         );
 
         let mut op_names = LayerOps::new();


### PR DESCRIPTION
This PR makes the lookup of PMI values more general by lowercasing all tokens before the lookup. Exceptions can be added in the form of PoS tags. For example, if the root token, common and proper nouns should not be lowercased, the tag list ["ROOT", "NN", "NE"] can be added to the configuration file.

A question on performance: Is there a faster way for
```
!list.contains(tag)
```
?

This refers to
```
!self.no_lowercase_tags.contains(&dependent_pos.to_string())
```
in `input_layer.rs`.